### PR TITLE
Increase 3rd party topic editing time limit to ~6 years

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -360,7 +360,7 @@ class Realm(models.Model):
     # Whether users have access to message edit history
     allow_edit_history: bool = models.BooleanField(default=True)
 
-    DEFAULT_COMMUNITY_TOPIC_EDITING_LIMIT_SECONDS = 259200
+    DEFAULT_COMMUNITY_TOPIC_EDITING_LIMIT_SECONDS = 200000000 # ~6 years
     allow_community_topic_editing: bool = models.BooleanField(default=True)
 
     # Defaults for new users


### PR DESCRIPTION
200_000_000 seconds so it comfortably fits into the Python int fast path. Not that that's likely to matter but that seemed like the easiest way to come up with a number 🤷‍♂️