### PR TITLE
Replace :smile: with :check: under popular emojis

### DIFF
--- a/static/shared/js/typeahead.js
+++ b/static/shared/js/typeahead.js
@@ -22,10 +22,10 @@
 export const popular_emojis = [
     "1f44d", // +1
     "1f389", // tada
-    "1f642", // smile
+    "1f419", // octopus
     "2764", // heart
     "1f6e0", // working_on_it
-    "1f419", // octopus
+    "2705", // check
 ];
 
 const unicode_marks = /\p{M}/gu;


### PR DESCRIPTION
Let's keep the cute :octopus: as :smile: is already available in the default visible emoji picker window.