### PR TITLE
tweak poll widget

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -88,9 +88,7 @@ elif vendor == "ubuntu" and os_version == "22.04":  # jammy
     POSTGRESQL_VERSION = "14"
 elif vendor == "neon" and os_version == "20.04":  # KDE Neon
     POSTGRESQL_VERSION = "12"
-elif vendor == "fedora" and os_version == "33":
-    POSTGRESQL_VERSION = "13"
-elif vendor == "fedora" and os_version == "34":
+elif vendor == "fedora":
     POSTGRESQL_VERSION = "13"
 elif vendor == "rhel" and os_version.startswith("7."):
     POSTGRESQL_VERSION = "10"

--- a/web/shared/src/poll_data.js
+++ b/web/shared/src/poll_data.js
@@ -19,6 +19,8 @@ export class PollData {
         options,
         comma_separated_names,
         report_error_function,
+        anonymous,
+        closed,
     }) {
         this.message_sender_id = message_sender_id;
         this.me = current_user_id;
@@ -27,6 +29,8 @@ export class PollData {
         this.input_mode = is_my_poll; // for now
         this.comma_separated_names = comma_separated_names;
         this.report_error_function = report_error_function;
+        this.anonymous = anonymous;
+        this.closed = closed;
 
         if (question) {
             this.set_question(question);
@@ -70,7 +74,7 @@ export class PollData {
 
             options.push({
                 option: obj.option,
-                names: this.comma_separated_names(voters),
+                names: this.anonymous ? [] : this.comma_separated_names(voters),
                 count: voters.length,
                 key,
                 current_user_vote,
@@ -80,6 +84,8 @@ export class PollData {
         const widget_data = {
             options,
             question: this.poll_question,
+            anonymous: this.anonymous,
+            closed: this.closed,
         };
 
         return widget_data;

--- a/web/shared/src/poll_data.js
+++ b/web/shared/src/poll_data.js
@@ -20,7 +20,7 @@ export class PollData {
         comma_separated_names,
         report_error_function,
         anonymous,
-        closed,
+        rigid,
     }) {
         this.message_sender_id = message_sender_id;
         this.me = current_user_id;
@@ -30,7 +30,7 @@ export class PollData {
         this.comma_separated_names = comma_separated_names;
         this.report_error_function = report_error_function;
         this.anonymous = anonymous;
-        this.closed = closed;
+        this.rigid = rigid;
 
         if (question) {
             this.set_question(question);
@@ -85,7 +85,7 @@ export class PollData {
             options,
             question: this.poll_question,
             anonymous: this.anonymous,
-            closed: this.closed,
+            rigid: this.rigid,
         };
 
         return widget_data;

--- a/web/shared/src/poll_data.js.flow
+++ b/web/shared/src/poll_data.js.flow
@@ -19,6 +19,8 @@ declare export class PollData {
         options: interface {entries(): Iterable<[number, string]>},
         comma_separated_names: (user_ids: number[]) => string,
         report_error_function: (msg: string) => void,
+        anonymous: boolean,
+        closed: boolean,
     }): void;
 
     set_question(question: string): void;
@@ -40,6 +42,8 @@ declare export class PollData {
             key: string,
             current_user_vote: boolean,
         }>,
+        anonymous: boolean,
+        closed: boolean,
     };
 
     handle_event(sender_id: number, data: PollEvent): void;

--- a/web/shared/src/poll_data.js.flow
+++ b/web/shared/src/poll_data.js.flow
@@ -20,7 +20,7 @@ declare export class PollData {
         comma_separated_names: (user_ids: number[]) => string,
         report_error_function: (msg: string) => void,
         anonymous: boolean,
-        closed: boolean,
+        rigid: boolean,
     }): void;
 
     set_question(question: string): void;
@@ -43,7 +43,7 @@ declare export class PollData {
             current_user_vote: boolean,
         }>,
         anonymous: boolean,
-        closed: boolean,
+        rigid: boolean,
     };
 
     handle_event(sender_id: number, data: PollEvent): void;

--- a/web/shared/src/typeahead.ts
+++ b/web/shared/src/typeahead.ts
@@ -20,10 +20,10 @@
 export const popular_emojis = [
     "1f44d", // +1
     "1f389", // tada
-    "1f642", // smile
+    "1f419", // octopus
     "2764", // heart
     "1f6e0", // working_on_it
-    "1f419", // octopus
+    "2705", // check
 ];
 
 const unicode_marks = /\p{M}/gu;

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -419,10 +419,10 @@ export const slash_commands = [
         placeholder: $t({defaultMessage: "Question"}),
     },
     {
-      text: $t({defaultMessage: "/poll-anon (Anonymous poll)"}),
-      name: "poll-anon",
-      aliases: "",
-      placeholder: $t({defaultMessage: "Question"}),
+        text: $t({defaultMessage: "/poll-anon (Anonymous poll)"}),
+        name: "poll-anon",
+        aliases: "",
+        placeholder: $t({defaultMessage: "Question"}),
     },
     {
         text: $t({defaultMessage: "/poll-anon-rigid (Anonymous, no new options)"}),

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -413,8 +413,8 @@ export const slash_commands = [
         placeholder: $t({defaultMessage: "Question"}),
     },
     {
-        text: $t({defaultMessage: "/poll-closed (No create option)"}),
-        name: "poll-closed",
+        text: $t({defaultMessage: "/poll-rigid (No new options)"}),
+        name: "poll-rigid",
         aliases: "",
         placeholder: $t({defaultMessage: "Question"}),
     },
@@ -425,8 +425,8 @@ export const slash_commands = [
       placeholder: $t({defaultMessage: "Question"}),
     },
     {
-        text: $t({defaultMessage: "/poll-anon-closed (Anonymous, no create option)"}),
-        name: "poll-anon-closed",
+        text: $t({defaultMessage: "/poll-anon-rigid (Anonymous, no new options)"}),
+        name: "poll-anon-rigid",
         aliases: "",
         placeholder: $t({defaultMessage: "Question"}),
     },

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -407,8 +407,26 @@ export const slash_commands = [
         aliases: "",
     },
     {
-        text: $t({defaultMessage: "/poll Where should we go to lunch today? (Create a poll)"}),
+        text: $t({defaultMessage: "/poll (Create a poll)"}),
         name: "poll",
+        aliases: "",
+        placeholder: $t({defaultMessage: "Question"}),
+    },
+    {
+        text: $t({defaultMessage: "/poll-closed (No create option)"}),
+        name: "poll-closed",
+        aliases: "",
+        placeholder: $t({defaultMessage: "Question"}),
+    },
+    {
+      text: $t({defaultMessage: "/poll-anon (Anonymous poll)"}),
+      name: "poll-anon",
+      aliases: "",
+      placeholder: $t({defaultMessage: "Question"}),
+    },
+    {
+        text: $t({defaultMessage: "/poll-anon-closed (Anonymous, no create option)"}),
+        name: "poll-anon-closed",
         aliases: "",
         placeholder: $t({defaultMessage: "Question"}),
     },

--- a/web/src/poll_widget.js
+++ b/web/src/poll_widget.js
@@ -12,7 +12,7 @@ import * as people from "./people";
 export function activate({
     $elem,
     callback,
-    extra_data: {question = "", options = [], anonymous = false, closed = false} = {},
+    extra_data: {question = "", options = [], anonymous = false, rigid = false} = {},
     message,
 }) {
     const is_my_poll = people.is_my_user_id(message.sender_id);
@@ -25,7 +25,7 @@ export function activate({
         comma_separated_names: people.get_full_names_for_poll_option,
         report_error_function: blueslip.warn,
         anonymous,
-        closed
+        rigid
     });
 
     function update_edit_controls() {

--- a/web/src/poll_widget.js
+++ b/web/src/poll_widget.js
@@ -25,7 +25,7 @@ export function activate({
         comma_separated_names: people.get_full_names_for_poll_option,
         report_error_function: blueslip.warn,
         anonymous,
-        rigid
+        rigid,
     });
 
     function update_edit_controls() {

--- a/web/src/poll_widget.js
+++ b/web/src/poll_widget.js
@@ -12,7 +12,7 @@ import * as people from "./people";
 export function activate({
     $elem,
     callback,
-    extra_data: {question = "", options = []} = {},
+    extra_data: {question = "", options = [], anonymous = false, closed = false} = {},
     message,
 }) {
     const is_my_poll = people.is_my_user_id(message.sender_id);
@@ -24,6 +24,8 @@ export function activate({
         options,
         comma_separated_names: people.get_full_names_for_poll_option,
         report_error_function: blueslip.warn,
+        anonymous,
+        closed
     });
 
     function update_edit_controls() {
@@ -117,7 +119,7 @@ export function activate({
     }
 
     function build_widget() {
-        const html = render_widgets_poll_widget();
+        const html = render_widgets_poll_widget(poll_data.get_widget_data());
         $elem.html(html);
 
         $elem.find("input.poll-question").on("keyup", (e) => {

--- a/web/src/widgetize.js
+++ b/web/src/widgetize.js
@@ -8,6 +8,9 @@ import * as todo_widget from "./todo_widget";
 import * as zform from "./zform";
 
 const widgets = new Map([
+    ["poll-anon", poll_widget],
+    ["poll-closed", poll_widget],
+    ["poll-anon-closed", poll_widget],
     ["poll", poll_widget],
     ["todo", todo_widget],
     ["zform", zform],

--- a/web/src/widgetize.js
+++ b/web/src/widgetize.js
@@ -9,8 +9,8 @@ import * as zform from "./zform";
 
 const widgets = new Map([
     ["poll-anon", poll_widget],
-    ["poll-closed", poll_widget],
-    ["poll-anon-closed", poll_widget],
+    ["poll-rigid", poll_widget],
+    ["poll-anon-rigid", poll_widget],
     ["poll", poll_widget],
     ["todo", todo_widget],
     ["zform", zform],

--- a/web/templates/widgets/poll_widget.hbs
+++ b/web/templates/widgets/poll_widget.hbs
@@ -14,7 +14,7 @@
     </div>
     <ul class="poll-widget">
     </ul>
-    {{#unless closed}}
+    {{#unless rigid}}
     <div class="poll-option-bar">
         <input type="text" class="poll-option" placeholder="{{t 'New option'}}" />
         <button class="poll-option">{{t "Add option" }}</button>

--- a/web/templates/widgets/poll_widget.hbs
+++ b/web/templates/widgets/poll_widget.hbs
@@ -14,9 +14,11 @@
     </div>
     <ul class="poll-widget">
     </ul>
+    {{#unless closed}}
     <div class="poll-option-bar">
         <input type="text" class="poll-option" placeholder="{{t 'New option'}}" />
         <button class="poll-option">{{t "Add option" }}</button>
     </div>
+    {{/unless}}
     <br />
 </div>

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -63,7 +63,6 @@ from zerver.models import (
     ArchivedAttachment,
     Attachment,
     Message,
-    Reaction,
     Stream,
     UserMessage,
     UserProfile,
@@ -150,11 +149,13 @@ def maybe_send_resolve_topic_notifications(
     # Compute the users who either sent or reacted to messages that
     # were moved via the "resolve topic' action. Only those users
     # should be eligible for this message being managed as unread.
-    affected_participant_ids = {message.sender_id for message in changed_messages} | set(
-        Reaction.objects.filter(message__in=changed_messages).values_list(
-            "user_profile_id", flat=True
-        )
-    )
+    # affected_participant_ids = {message.sender_id for message in changed_messages} | set(
+    #     Reaction.objects.filter(message__in=changed_messages).values_list(
+    #         "user_profile_id", flat=True
+    #     )
+    # )
+    # Lichess change: always mark "topic resolved" messages as read for everybody
+    affected_participant_ids = set()
     sender = get_system_bot(settings.NOTIFICATION_BOT, user_profile.realm_id)
     user_mention = silent_mention_syntax_for_user(user_profile)
     with override_language(stream.realm.default_language):

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -7,7 +7,7 @@ from zerver.models import Message, SubMessage
 
 
 def get_widget_data(content: str) -> Tuple[Optional[str], Optional[str]]:
-    valid_widget_types = ["poll", "poll-anon", "poll-closed", "poll-anon-closed", "todo"]
+    valid_widget_types = ["poll", "poll-anon", "poll-rigid", "poll-anon-rigid", "todo"]
     tokens = content.split(" ")
 
     # tokens[0] will always exist
@@ -22,8 +22,8 @@ def get_widget_data(content: str) -> Tuple[Optional[str], Optional[str]]:
 
 
 def get_extra_data_from_widget_type(content: str, widget_type: Optional[str]) -> Any:
-    if widget_type in ["poll", "poll-anon", "poll-closed", "poll-anon-closed"]:
-        closed = widget_type.endswith("-closed")
+    if widget_type in ["poll", "poll-anon", "poll-rigid", "poll-anon-rigid"]:
+        rigid = widget_type.endswith("-rigid")
         anonymous = widget_type.startswith("poll-anon")
         # This is used to extract the question from the poll command.
         # The command '/poll question' will pre-set the question in the poll
@@ -42,7 +42,7 @@ def get_extra_data_from_widget_type(content: str, widget_type: Optional[str]) ->
             "question": question,
             "options": options,
             "anonymous": anonymous,
-            "closed": closed,
+            "rigid": rigid,
         }
         return extra_data
     return None

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -7,7 +7,7 @@ from zerver.models import Message, SubMessage
 
 
 def get_widget_data(content: str) -> Tuple[Optional[str], Optional[str]]:
-    valid_widget_types = ["poll", "todo"]
+    valid_widget_types = ["poll", "poll-anon", "poll-closed", "poll-anon-closed", "todo"]
     tokens = content.split(" ")
 
     # tokens[0] will always exist
@@ -22,7 +22,9 @@ def get_widget_data(content: str) -> Tuple[Optional[str], Optional[str]]:
 
 
 def get_extra_data_from_widget_type(content: str, widget_type: Optional[str]) -> Any:
-    if widget_type == "poll":
+    if widget_type in ["poll", "poll-anon", "poll-closed", "poll-anon-closed"]:
+        closed = widget_type.endswith("-closed")
+        anonymous = widget_type.startswith("poll-anon")
         # This is used to extract the question from the poll command.
         # The command '/poll question' will pre-set the question in the poll
         lines = content.splitlines()
@@ -39,6 +41,8 @@ def get_extra_data_from_widget_type(content: str, widget_type: Optional[str]) ->
         extra_data = {
             "question": question,
             "options": options,
+            "anonymous": anonymous,
+            "closed": closed,
         }
         return extra_data
     return None

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -195,6 +195,8 @@ class WidgetContentTestCase(ZulipTestCase):
             extra_data=dict(
                 options=["Red", "Green", "Blue", "Yellow"],
                 question="What is your favorite color?",
+                anonymous=False,
+                rigid=False,
             ),
         )
 
@@ -214,6 +216,8 @@ class WidgetContentTestCase(ZulipTestCase):
             extra_data=dict(
                 options=[],
                 question="",
+                anonymous=False,
+                rigid=False,
             ),
         )
 


### PR DESCRIPTION
add a few options to poll widget:
- /poll-rigid - like /poll but users can't create new options after poll creation
- /poll-anon - like /poll but usernames aren't rendered in results
- /poll-anon-rigid - combo of /poll-rigid and /poll-anon